### PR TITLE
Update min-length of user-pin to support new tokens

### DIFF
--- a/src/pkcs15init/rutoken_ecp.profile
+++ b/src/pkcs15init/rutoken_ecp.profile
@@ -48,7 +48,7 @@ PIN user-pin {
     auth-id     = 2;
     reference   = 2;
     attempts    = 5;
-    min-length  = 4;
+    min-length  = 6;
     max-length  = 32;
     flags       = case-sensitive, initialized;
 }


### PR DESCRIPTION
Rutoken ECP BIO requires min-length param for user/so PIN to be greater than 6 bytes